### PR TITLE
fix: 팀 게시물 상세 조회 오류 수정

### DIFF
--- a/src/main/java/soccerTeam/dto/SoccerTeamDto.java
+++ b/src/main/java/soccerTeam/dto/SoccerTeamDto.java
@@ -1,22 +1,17 @@
 package soccerTeam.dto;
 
-import java.sql.Date;
-import java.sql.Time;
-import java.text.SimpleDateFormat;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.RequiredArgsConstructor;
-import soccerTeam.player.repository.PlayerEntity;
+import lombok.*;
+import soccerTeam.player.dto.response.PlayerProfileResponse;
 
 @Data
 @AllArgsConstructor
 public class SoccerTeamDto {
     private Long id;
-    private PlayerEntity player;
+    private PlayerProfileResponse player;
     private String title;
     private String name;
     private String region;

--- a/src/main/java/soccerTeam/image/repository/JpaSoccerTeamFileRepository.java
+++ b/src/main/java/soccerTeam/image/repository/JpaSoccerTeamFileRepository.java
@@ -7,6 +7,6 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface JpaSoccerTeamFileRepository extends JpaRepository<SoccerTeamFileEntity, Long> {
-    @Query("SELECT sfe FROM SoccerTeamFileEntity sfe WHERE sfe.soccerTeam = :teamId")
+    @Query("SELECT sfe FROM SoccerTeamFileEntity sfe WHERE sfe.soccerTeam.id = :teamId")
     List<SoccerTeamFileEntity> findByTeamId(@Param("teamId") Long teamId);
 }

--- a/src/main/java/soccerTeam/player/controller/RestJoinController.java
+++ b/src/main/java/soccerTeam/player/controller/RestJoinController.java
@@ -1,12 +1,11 @@
 package soccerTeam.player.controller;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import soccerTeam.dto.ApiResponse;
 import soccerTeam.dto.JoinDto;
+import soccerTeam.player.dto.response.PlayerProfileResponse;
 import soccerTeam.player.dto.response.PlayerSimpleResponse;
 import soccerTeam.player.service.JoinService;
 import soccerTeam.type.player.PlayerSuccessType;

--- a/src/main/java/soccerTeam/player/dto/response/PlayerProfileResponse.java
+++ b/src/main/java/soccerTeam/player/dto/response/PlayerProfileResponse.java
@@ -1,0 +1,25 @@
+package soccerTeam.player.dto.response;
+
+import soccerTeam.player.repository.PlayerEntity;
+
+public record PlayerProfileResponse(
+        Long id,
+        String name,
+        String email,
+        String username,
+        String phoneNumber,
+        Integer period,
+        Integer age,
+        Boolean athlete) {
+    public static PlayerProfileResponse of(PlayerEntity player) {
+        return new PlayerProfileResponse(
+                player.getId(),
+                player.getName(),
+                player.getEmail(),
+                player.getUsername(),
+                player.getPhoneNumber(),
+                player.getPeriod(),
+                player.getAge(),
+                player.getAthlete());
+    }
+}

--- a/src/main/java/soccerTeam/player/dto/response/PlayerSimpleResponse.java
+++ b/src/main/java/soccerTeam/player/dto/response/PlayerSimpleResponse.java
@@ -1,6 +1,4 @@
 package soccerTeam.player.dto.response;
 
-public record PlayerSimpleResponse(
-        Long id,
-        String username) {
+public record PlayerSimpleResponse(Long id, String username) {
 }

--- a/src/main/java/soccerTeam/player/repository/PlayerEntity.java
+++ b/src/main/java/soccerTeam/player/repository/PlayerEntity.java
@@ -10,11 +10,12 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 
 @Data
 @Entity
-@RequiredArgsConstructor
+@NoArgsConstructor
 public class PlayerEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/soccerTeam/player/service/JoinService.java
+++ b/src/main/java/soccerTeam/player/service/JoinService.java
@@ -1,6 +1,7 @@
 package soccerTeam.player.service;
 
 import soccerTeam.dto.JoinDto;
+import soccerTeam.player.dto.response.PlayerProfileResponse;
 import soccerTeam.player.dto.response.PlayerSimpleResponse;
 
 public interface JoinService {

--- a/src/main/java/soccerTeam/player/service/JoinServiceImpl.java
+++ b/src/main/java/soccerTeam/player/service/JoinServiceImpl.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 
 import soccerTeam.dto.JoinDto;
 import soccerTeam.exception.BadRequestException;
+import soccerTeam.player.dto.response.PlayerProfileResponse;
 import soccerTeam.player.dto.response.PlayerSimpleResponse;
 import soccerTeam.player.repository.PlayerEntity;
 import soccerTeam.player.repository.PlayerRepository;

--- a/src/main/java/soccerTeam/team/controller/RestSoccerTeamController.java
+++ b/src/main/java/soccerTeam/team/controller/RestSoccerTeamController.java
@@ -63,7 +63,7 @@ public class RestSoccerTeamController {
     }
 
     @GetMapping("/{teamIdx}")
-    public ResponseEntity<Map<String, Object>> getSoccerTeamDetail(@PathVariable("teamIdx") Long teamIdx) throws Exception {
+    public ApiResponse<SoccerTeamDto> getSoccerTeamDetail(@PathVariable("teamIdx") Long teamIdx) throws Exception {
         SoccerTeamDto soccerTeamDtoResult = soccerTeamService.selectSoccerTeamDetail(teamIdx);
 //        if (soccerTeamDtoResult == null) {
 //            Map<String, Object> result = new HashMap<>();
@@ -77,7 +77,7 @@ public class RestSoccerTeamController {
 //            response.put("playerList", playerList);
 //            return ResponseEntity.status(HttpStatus.OK).body(response);
 //        }
-        return null;
+        return ApiResponse.success(SoccerTeamSuccessType.GET_SOCCER_TEAM_SUCCESS, soccerTeamDtoResult);
     }
 
     @PutMapping

--- a/src/main/java/soccerTeam/team/repository/SoccerTeamEntity.java
+++ b/src/main/java/soccerTeam/team/repository/SoccerTeamEntity.java
@@ -1,7 +1,6 @@
 package soccerTeam.team.repository;
 
 
-import java.sql.Time;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
@@ -16,6 +15,7 @@ import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import soccerTeam.dto.SoccerTeamDto;
 import soccerTeam.dto.SoccerTeamFileDto;
+import soccerTeam.player.dto.response.PlayerProfileResponse;
 import soccerTeam.player.repository.PlayerEntity;
 import soccerTeam.team.dto.request.SoccerTeamInsertRequest;
 
@@ -146,7 +146,7 @@ public class SoccerTeamEntity {
 	public SoccerTeamDto toModel(List<SoccerTeamFileDto> files) {
 		return new SoccerTeamDto(
 				id,
-				player,
+				PlayerProfileResponse.of(player),
 				title,
 				name,
 				region,

--- a/src/main/java/soccerTeam/type/enroll/EnrollSuccessType.java
+++ b/src/main/java/soccerTeam/type/enroll/EnrollSuccessType.java
@@ -15,11 +15,11 @@ public enum EnrollSuccessType implements SuccessType {
 
     @Override
     public String getCode() {
-        return null;
+        return this.code;
     }
 
     @Override
     public String getMessage() {
-        return null;
+        return this.message;
     }
 }

--- a/src/main/java/soccerTeam/type/soccerTeam/SoccerTeamErrorType.java
+++ b/src/main/java/soccerTeam/type/soccerTeam/SoccerTeamErrorType.java
@@ -15,11 +15,11 @@ public enum SoccerTeamErrorType implements ErrorType {
 
     @Override
     public String getCode() {
-        return null;
+        return this.code;
     }
 
     @Override
     public String getMessage() {
-        return null;
+        return this.message;
     }
 }

--- a/src/main/java/soccerTeam/type/soccerTeam/SoccerTeamSuccessType.java
+++ b/src/main/java/soccerTeam/type/soccerTeam/SoccerTeamSuccessType.java
@@ -3,7 +3,8 @@ package soccerTeam.type.soccerTeam;
 import soccerTeam.type.SuccessType;
 
 public enum SoccerTeamSuccessType implements SuccessType {
-    GET_SOCCER_TEAM_LIST_SUCCESS("SOCCER_TEAM_1", "팀 목록 조회에 성공하였습니다");
+    GET_SOCCER_TEAM_LIST_SUCCESS("SOCCER_TEAM_1", "팀 목록 조회에 성공하였습니다"),
+    GET_SOCCER_TEAM_SUCCESS("SOCCER_TEAM_2", "팀 단일 조회에 성공하였습니다");
 
     private final String code;
     private final String message;
@@ -15,11 +16,11 @@ public enum SoccerTeamSuccessType implements SuccessType {
 
     @Override
     public String getCode() {
-        return null;
+        return this.code;
     }
 
     @Override
     public String getMessage() {
-        return null;
+        return this.message;
     }
 }


### PR DESCRIPTION
**Description**
- 팀 게시물 상세 조회 응답 스펙을 규격화 하였습니다. (`ApiResponse` 적용)
- 회원 정보의 비밀번호 등 개인정보까지 조회되지 않도록, `PlayerProfileResponse`를 만들어 적용했습니다.
- 응답 예시 입니다.
<img width="301" alt="Screenshot 2024-08-23 at 16 08 24" src="https://github.com/user-attachments/assets/511817c7-7fa6-40d9-abb1-92d791f60876">