### PR TITLE
fix: 입단신청서 소유자 확인

### DIFF
--- a/src/main/java/soccerTeam/enroll/controller/EnrollController.java
+++ b/src/main/java/soccerTeam/enroll/controller/EnrollController.java
@@ -5,8 +5,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import soccerTeam.dto.ApiResponse;
 import soccerTeam.enroll.dto.*;
@@ -15,6 +14,7 @@ import soccerTeam.security.LoginMember;
 import soccerTeam.type.enroll.EnrollSuccessType;
 import lombok.extern.slf4j.Slf4j;
 
+import java.security.Principal;
 import java.util.List;
 
 @Slf4j
@@ -55,15 +55,17 @@ public class EnrollController {
     @Operation(summary = "입단 신청서 상세 조회", description = "입단 신청서를 상세 조회합니다.")
     @GetMapping("/{enrollId}")
     public ApiResponse<EnrollDto> getEnrollDetail(
-            @Parameter(description = "입단 신청서 id", required = true) @PathVariable("enrollId") Long enrollId) {
-        EnrollDto enrollDto = enrollService.findByIdAndUpdateHitCnt(enrollId);
+            @Parameter(description = "입단 신청서 id", required = true) @PathVariable("enrollId") Long enrollId,
+            @RequestHeader("Authorization") String token) {
+        EnrollDto enrollDto = enrollService.findByIdAndUpdateHitCnt(enrollId, token);
         return ApiResponse.success(EnrollSuccessType.ENROLL_SUCCESS, enrollDto);
     }
 
     @Operation(summary = "입단 신청서 삭제", description = "입단 신청서를 삭제합니다.")
     @DeleteMapping("/{enrollId}")
-    public ApiResponse<Void> deleteEnroll(@PathVariable("enrollId") Long enrollId, @LoginMember String username) {
-        enrollService.deleteById(enrollId, username);
+    public ApiResponse<Void> deleteEnroll(@PathVariable("enrollId") Long enrollId,
+                                          @RequestHeader("Authorization") String token) {
+        enrollService.deleteById(enrollId, token);
         return ApiResponse.success(EnrollSuccessType.DELETE_SUCCESS, null);
     }
 }

--- a/src/main/java/soccerTeam/enroll/controller/EnrollController.java
+++ b/src/main/java/soccerTeam/enroll/controller/EnrollController.java
@@ -63,9 +63,10 @@ public class EnrollController {
 
     @Operation(summary = "입단 신청서 삭제", description = "입단 신청서를 삭제합니다.")
     @DeleteMapping("/{enrollId}")
-    public ApiResponse<Void> deleteEnroll(@PathVariable("enrollId") Long enrollId,
-                                          @RequestHeader("Authorization") String token) {
-        enrollService.deleteById(enrollId, token);
+    public ApiResponse<Void> deleteEnroll(
+            @PathVariable("enrollId") Long enrollId,
+            @LoginMember String username) {
+        enrollService.deleteById(enrollId, username);
         return ApiResponse.success(EnrollSuccessType.DELETE_SUCCESS, null);
     }
 }

--- a/src/main/java/soccerTeam/enroll/dto/EnrollDto.java
+++ b/src/main/java/soccerTeam/enroll/dto/EnrollDto.java
@@ -50,9 +50,8 @@ public class EnrollDto {
     @Schema(description = "마지막으로 수정된 시간", example = "2024-08-27T10:15:30")
     private LocalDateTime updatedAt;
 
-    @JsonProperty("isOwner")
     @Schema(description = "현재 사용자가 작성자인지 여부", example = "true")
-    private boolean isOwner;
+    private Boolean isOwner;
 
     public static EnrollDto of(EnrollEntity enroll, boolean isOwner) {
         return EnrollDto.builder()

--- a/src/main/java/soccerTeam/enroll/dto/EnrollDto.java
+++ b/src/main/java/soccerTeam/enroll/dto/EnrollDto.java
@@ -1,5 +1,6 @@
 package soccerTeam.enroll.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
@@ -49,7 +50,11 @@ public class EnrollDto {
     @Schema(description = "마지막으로 수정된 시간", example = "2024-08-27T10:15:30")
     private LocalDateTime updatedAt;
 
-    public static EnrollDto of(EnrollEntity enroll) {
+    @JsonProperty("isOwner")
+    @Schema(description = "현재 사용자가 작성자인지 여부", example = "true")
+    private boolean isOwner;
+
+    public static EnrollDto of(EnrollEntity enroll, boolean isOwner) {
         return EnrollDto.builder()
                 .id(enroll.getId())
                 .player(PlayerProfileResponse.of(enroll.getPlayer()))
@@ -61,6 +66,7 @@ public class EnrollDto {
                 .region(enroll.getPlayer().getRegion())
                 .createdAt(enroll.getCreatedAt())
                 .updatedAt(enroll.getUpdatedAt())
+                .isOwner(isOwner) // 작성자인지 여부 설정
                 .build();
     }
 }

--- a/src/main/java/soccerTeam/enroll/service/EnrollService.java
+++ b/src/main/java/soccerTeam/enroll/service/EnrollService.java
@@ -11,7 +11,7 @@ public interface EnrollService {
 
     EnrollUpdateDto updateEnroll(String username, EnrollUpdateRequest updateRequest);
 
-    EnrollDto findByIdAndUpdateHitCnt(Long id);
+    EnrollDto findByIdAndUpdateHitCnt(Long id, String username);
 
     void deleteById(Long id, String username);
 }

--- a/src/main/java/soccerTeam/enroll/service/EnrollService.java
+++ b/src/main/java/soccerTeam/enroll/service/EnrollService.java
@@ -11,7 +11,7 @@ public interface EnrollService {
 
     EnrollUpdateDto updateEnroll(String username, EnrollUpdateRequest updateRequest);
 
-    EnrollDto findByIdAndUpdateHitCnt(Long id, String username);
+    EnrollDto findByIdAndUpdateHitCnt(Long id, String token);
 
     void deleteById(Long id, String username);
 }

--- a/src/main/java/soccerTeam/enroll/service/EnrollServiceImpl.java
+++ b/src/main/java/soccerTeam/enroll/service/EnrollServiceImpl.java
@@ -29,7 +29,6 @@ import soccerTeam.type.soccerTeam.SoccerTeamErrorType;
 import java.time.LocalDateTime;
 import java.util.List;
 
-@Slf4j  // 이 애너테이션으로 log 객체를 초기화합니다.
 @Service
 @RequiredArgsConstructor
 public class EnrollServiceImpl implements EnrollService {

--- a/src/main/java/soccerTeam/enroll/service/EnrollServiceImpl.java
+++ b/src/main/java/soccerTeam/enroll/service/EnrollServiceImpl.java
@@ -29,6 +29,7 @@ import soccerTeam.type.soccerTeam.SoccerTeamErrorType;
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class EnrollServiceImpl implements EnrollService {
@@ -94,12 +95,10 @@ public class EnrollServiceImpl implements EnrollService {
 
     @Override
     @Transactional
-    public void deleteById(Long id, String token) {
+    public void deleteById(Long id, String username) {
         EnrollEntity enroll = jpaEnrollRepository.findById(id)
                 .orElseThrow(() -> new NotFoundException(EnrollErrorType.ENROLL_NOT_FOUND));
-
-        boolean isOwner = checkOwner(enroll, token);
-        if (!isOwner) {
+        if (!enroll.getPlayer().getUsername().equals(username)) {
             throw new UnauthorizedException(EnrollErrorType.ONLY_OWNER_CAN_MODIFY);
         }
         jpaEnrollRepository.deleteById(id);


### PR DESCRIPTION
- EnrollController
    - getEnrollDetail 메서드에서 클라이언트로부터 받은 JWT 토큰을 사용하여 요청한 사용자가 해당 게시글의 작성자인지 확인합니다.
    - 삭제 진행 시 검증 필요 메시지가 출력되어 deleteEnroll 메서드에서 요청한 사용자가 해당 게시글의 작성자인 경우에만 삭제가 가능하도록 변경했습니다.
 
- Service
    - findByIdAndUpdateHitCnt 메서드가 엔터티의 조회수를 증가시키기 위해 엔티티를 조회하고 반환 과정에 그 엔터티의 작성자가 현재 요청을 보내고 있는 사용자와 일치하는지를 판단도록 했습니다.
    - findByIdAndUpdateHitCnt에서 isOwner를 판단하지 않고, 별도의 checkOwner 메서드로 처리하도록 하였습니다.
    - checkOwner 메서드에서 JWT 토큰을 분석하여 사용자 이름을 추출하고, 해당 사용자가 게시글 작성자인지 확인합니다.

- EnrollDto
    - @JsonProperty("isOwner") 를 사용하여 Jackson 같은 JSON 변환 라이브러리가 기본적으로 `isOwner`라는 필드를 `owner`로 직렬화하여 변환하는 것을 방지했습니다.

- playerId: 4인 test123유저가 작성한 id: 9 게시글을 조회했을 때 isOwner: true가 되는지 확인했습니다.
- 본인 소유가 아닌 id: 8 게시글을 확인했을 때 isOwner: false가 되는지 확인했습니다.
<img width="1006" alt="image" src="https://github.com/user-attachments/assets/1c28f31f-cfd5-4fe5-b3b1-761e8864706c">

<img width="1006" alt="image" src="https://github.com/user-attachments/assets/4fce86ad-4413-434f-aa41-dc06731cac47">

<img width="1489" alt="image" src="https://github.com/user-attachments/assets/db91077a-16d5-4e99-9e6d-c2dd0070c015">

<img width="1490" alt="image" src="https://github.com/user-attachments/assets/b5b71e9e-bec2-4419-94df-79e045a7521c">

--------------------------------------------------------

- 코멘트 모두 반영하여 수정하였습니다.
- EnrollController의 deleteEnroll에서 @LoginMember를 사용했기 때문에 ServieImpl의 deleteById을 username을 사용했던 때로 돌려놓았습니다.
