### PR TITLE
fix: 팀 게시글 조회 시 수정일 업데이트되던 것

### DIFF
--- a/src/main/java/soccerTeam/team/service/SoccerTeamServiceImpl.java
+++ b/src/main/java/soccerTeam/team/service/SoccerTeamServiceImpl.java
@@ -69,7 +69,7 @@ public class SoccerTeamServiceImpl implements SoccerTeamService {
     }
 
     @Override
-    @Transactional
+    @Transactional( readOnly = true)
     public SoccerTeamDto selectSoccerTeamDetail(Long teamIdx, String authorizationHeader) {
         SoccerTeamEntity soccerTeam = soccerTeamRepository.updateHitCount(teamIdx)
                 .orElseThrow(() -> new NotFoundException(SoccerTeamErrorType.TEAM_NOT_FOUND));


### PR DESCRIPTION
~~updateHitCount 메서드에서 조회수를 증가시키는 과정에서 엔티티의 updatedAt 필드가 자동으로 갱신되기 때문에 수정일(updatedAt)이 갱신되는 문제가 발생했습니다. 그 때문에 조회수를 증가시키는 updateHitCount 메서드가 호출될 때마다 updatedAt 필드도 갱신되었습니다.~~

~~문제를 해결할 수 있는 방법 중 코드를 크게 바꾸지않고 가장 간단하게 해결할 수 있는 방법으로 수정했습니다.~~

~~- selectSoccerTeamDetail에서의 조회 작업은 @Transactional에 readOnly(읽기 전용)로 설정하여 엔티티의 updatedAt이 갱신되지 않도록 했습니다.~~
~~- updateSoccerTeam에서의 수정 작업은 @Transactional만을 적용하여 수정 작업이 제대로 수행되도록 합니다. 그럼 엔티티의 updatedAt도 함께 갱신되어 수정일이 업데이트됩니다.~~

별별 방법을 다 해보고 있는데 아직까지 해결 못했습니다... 죄송합니다...