### PR TITLE
feat: docker-compose file 생성 및 실행

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ build/
 !**/src/test/**/build/
 **/application-secret.properties
 files/
+.env
 
 ### STS ###
 .apt_generated

--- a/build.gradle
+++ b/build.gradle
@@ -68,5 +68,5 @@ tasks.named('test') {
 jar { enabled = false }
 
 bootJar {
-	archiveFileName.set('teamsoccer-server')
+	archiveFileName.set('teamsoccer-server.jar')
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3.8'
+
+services:
+  backend:
+    image: ltt908/teamsoccer-server:0.1
+    container_name: teamsoccer-server
+    ports:
+      - "8080:8080"
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:mysql://${RDS_HOSTNAME}:${RDS_PORT}/${MYSQL_DATABASE}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+      SPRING_DATASOURCE_USERNAME: ${RDS_USERNAME}
+      SPRING_DATASOURCE_PASSWORD: ${RDS_PASSWORD}
+    networks:
+      - app-network
+
+networks:
+  app-network:
+    driver: bridge

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,7 +21,6 @@ spring:
     defer-datasource-initialization: false
     properties:
       hibernate:
-        dialect: org.hibernate.dialect.MySQL8Dialect
         format_sql: true
         default_batch_fetch_size: 100
     show-sql: true


### PR DESCRIPTION
- docker-compose file 생성 및 실행
- frontend와 backend에서 각자 이미지를 만들어 dockerhub에 등록 후, database는 aws의 RDS를 사용하여 docker compose를 
실행했습니다.

![image](https://github.com/user-attachments/assets/08c47792-890f-46e2-ad0a-cf229f38f92f)
![image](https://github.com/user-attachments/assets/117b831a-4977-4e3a-82b7-f445989cc5a6)
- 그 후 localhost로 접속해 제대로 application이 작동하는 것을 확인했습니다.

